### PR TITLE
fix(docker compose): add environment to elasticsearch

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,6 +104,7 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
Without the environment, all indices on the elasticsearch node will be readonly.