### PR TITLE
refactor : remove invalid es go mod version and redis has duplicate code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/denis-tingaikin/go-header v0.4.3 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/elastic/go-elasticsearch v0.0.0
 	github.com/elastic/go-elasticsearch/v7 v7.17.10
 	github.com/esimonov/ifshort v1.0.4 // indirect
 	github.com/ettle/strcase v0.1.1 // indirect

--- a/src/storage/redis/redis.go
+++ b/src/storage/redis/redis.go
@@ -22,7 +22,4 @@ func init() {
 		panic(err)
 	}
 
-	if err := redisotel.InstrumentMetrics(Client); err != nil {
-		panic(err)
-	}
 }


### PR DESCRIPTION
 the go es version 0.0.0 is invalid and the resdis go file has duplicate code
```go
func init() {
	addrs := strings.Split(config.EnvCfg.RedisAddr, ";")
	Client = redis.NewUniversalClient(&redis.UniversalOptions{
		Addrs:      addrs,
		Password:   config.EnvCfg.RedisPassword,
		DB:         config.EnvCfg.RedisDB,
		MasterName: config.EnvCfg.RedisMaster,
	})

	if err := redisotel.InstrumentTracing(Client); err != nil {
		panic(err)
	}
       
        //duplicate code
	if err := redisotel.InstrumentMetrics(Client); err != nil {
		panic(err)
	}
}

```